### PR TITLE
Added feature to display errors for certain links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ My first repository on Github for Release 0.1
 This is a CLI Tool made in Node.js to take a file name as argument, then scan each valid URL found within the document for their availability.
 
 Features:
-1. Color coded outputs, 🟢green for good links, 🔴red for bad links, and ⚫gray for unknown links.
+1. Color coded outputs, 🟢green for good links, 🔴red for bad links, 🟡yellow for links with errors and ⚫gray for unknown links.
 2. Supports windows and unix arguments for version display.
 
 Arguments available: 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a CLI Tool made in Node.js to take a file name as argument, then scan ea
 Features:
 1. Color coded outputs, 🟢green for good links, 🔴red for bad links, 🟡yellow for links with errors and ⚫gray for unknown links.
 2. Supports windows and unix arguments for version display.
-
+3. Request timeout is set to 5 seconds to prevent program from freezing, other errors are catched and displayed back to the client.
 Arguments available: 
 1. --v (or --version, /v or /version to view the current tool's version.)
 2. [filename] (will scan the file of URLs and determine their availability.)

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,11 +5,7 @@ const fs = require('fs');
 const colors = require('colors');
 const axios = require('axios');
 
-//setting regex expression for URLs
-//const urlRegex = /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,})/g;
-//const urlRegex = /(https?:\/\/[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/[a-zA-Z0-9]+\.[^\s]{2,})/g;
 const urlRegex = /(https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,9}\b([-a-zA-Z0-9()@:%_\+.~#?&\/\/;=]*))/g;
-
 
 function versionOption(rawArgs) {
     const args = arg({
@@ -24,12 +20,8 @@ function versionOption(rawArgs) {
     };
 }
 
-function sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
-}
 
-
-async function displayResult(data) {
+function displayResult(data) {
 
     var goodLinks = 0;
     var badLinks = 0;
@@ -42,15 +34,13 @@ async function displayResult(data) {
     let match = urlRegex.exec(data);
     while (match) {
         const siteName = match[1];
-        //console.log(siteName);
 
         axios({
             method: 'GET',
             url: siteName,
+            setTimeout: 5000,
             validateStatus: () => true
         }).then(res => {
-            //console.log(res.status);
-
             if (res.status == 200) {
                 console.log("|Good|\t\t".bgGreen.black + siteName.green);
                 goodLinks++;
@@ -65,31 +55,15 @@ async function displayResult(data) {
             }
 
         }).catch((error) => {
-            //console.log({error})
             unloadedLinks++;
-        });;
+            console.log("|Error|\t".bgYellow.black + siteName.yellow + "\t" + error);
+        });
         totalLinks++;
         match = urlRegex.exec(data);
         if (!match){
             doneMatch = true;
         }
     }
-    
-    await sleep(3000);
-    var links = {goodLinks, badLinks, unknownLinks, unloadedLinks, totalLinks}
-    return Promise.resolve(links);
-
-}
-
-async function displayMsg(data){
-    const a = await displayResult(data);
-    
-    // console.log("\nRESULTS:".yellow);
-    // console.log("Good Links: ".bgGreen.black + a.goodLinks);
-    // console.log("Bad Links: ".bgRed.black + a.badLinks);
-    // console.log("Unknown Links: ".bgWhite.black + a.unknownLinks);
-    // console.log("Unloaded Links: " + a.unloadedLinks);
-    // console.log("Total Links: " + a.totalLinks);
 }
 
 export function cli(args) {
@@ -117,24 +91,14 @@ export function cli(args) {
                 if (err) {
                     return console.log(err);
                 }
-                //data = text file contents
-                //console.log(data);
 
                 console.log("\nValid URLs from \'".yellow + args[2].yellow + "\':\n".yellow);
-
-                //displayResult(data);
-                displayMsg(data);
-
+                displayResult(data);
             });
-
         }
         else {
             console.log(args[2]);
         }
-
-
-
     }
-
-
+    
 }


### PR DESCRIPTION
Fixes #9 

Since requests for certain urls may time out, 5 seconds of timeout is set upon sending the request, this will prevent long/infinite wait time for a response from the server.

Other errors are also caught and displayed back to the client.

Unused codes are removed rather than commented out.